### PR TITLE
Updating Roulette odds for Roulette Remix

### DIFF
--- a/consts/randomChaoItemList.go
+++ b/consts/randomChaoItemList.go
@@ -21,33 +21,33 @@ var RandomChaoWheelCharacterPrizes = map[string]float64{
 	enums.CTStrKnuckles: 0.81, // Obtained in story mode - all groups
 	// enums.CTStrAmy:      0.81, //Group 2
 	// enums.CTStrBig:      0.81, //Group 2
-	enums.CTStrBlaze:           0.81, //Group 3
-	//enums.CTStrCharmy: 0.81, //Group 1
+	//enums.CTStrBlaze:           0.81, //Group 3
+	enums.CTStrCharmy: 0.81, //Group 1
 	// enums.CTStrCream:  0.81, //Group 2
-	//enums.CTStrEspio:  0.81, //Group 1
+	enums.CTStrEspio:  0.81, //Group 1
 	//enums.CTStrMephiles:        0.81, // Group 2
-	//enums.CTStrOmega: 0.81, //Group 1
+	enums.CTStrOmega: 0.81, //Group 1
 	//enums.CTStrPSISilver:       0.81, // Group 2
-	//enums.CTStrRouge:  0.81, //Group 1
-	//enums.CTStrShadow: 0.81, //Group 1
-	enums.CTStrMarine:          0.81, // Group 3
-	enums.CTStrTangle: 0.81, // Group 3
-	enums.CTStrWhisper: 0.81, // Group 3
-	enums.CTStrSticks:          0.81, // Group 3
-	enums.CTStrTikal:           0.81, // Group 3
-	//enums.CTStrVector: 0.81, //Group 1
-	enums.CTStrWerehog:         0.81, // Group 3
+	enums.CTStrRouge:  0.81, //Group 1
+	enums.CTStrShadow: 0.81, //Group 1
+	//enums.CTStrMarine:          0.81, // Group 3
+	//enums.CTStrTangle: 0.81, // Group 3
+	//enums.CTStrWhisper: 0.81, // Group 3
+	//enums.CTStrSticks:          0.81, // Group 3
+	//enums.CTStrTikal:           0.81, // Group 3
+	enums.CTStrVector: 0.81, //Group 1
+	//enums.CTStrWerehog:         0.81, // Group 3
 	//enums.CTStrClassicSonic: 0.81, // Group 2
-	//enums.CTStrMetalSonic:      0.81, // Group 1
+	enums.CTStrMetalSonic:      0.81, // Group 1
 	//enums.CTStrSilver:      0.81, // Group 2
 
-	enums.CTStrAmitieAmy:       1.81, // Event (Puyo Puyo Quest)
+	//enums.CTStrAmitieAmy:       1.81, // Event (Puyo Puyo Quest)
 	// enums.CTStrGothicAmy:       0.0, // Revival Event
 	// enums.CTStrHalloweenShadow: 1.0, // Event (Halloween)
 	// enums.CTStrHalloweenRouge:  1.0, // Event (Halloween)
 	// enums.CTStrHalloweenOmega:  1.0, // Event (Halloween)
 	// enums.CTStrXMasSonic:       1.0, // Event (Christmas)
-	// enums.CTStrXMasTails:       1.0, // Event (Christmas)
+	enums.CTStrXMasTails:       1.81, // Event (Christmas)
 	// enums.CTStrXMasKnuckles:    1.0, // Event (Christmas)
 	// enums.CTStrXT:              1.2, // Revival Event (Christmas)
 }
@@ -56,69 +56,69 @@ var RandomChaoWheelChaoPrizes = map[string]float64{
 	// TODO: Balance these
 	//enums.ChaoIDStrHeroChao:             3.0, // Event (Animal Rescue event 1.0)
 	//enums.ChaoIDStrGoldChao:             3.0, // Event (Animal Rescue event 1.0)
-	//enums.ChaoIDStrDarkChao:             3.0, // Event (Animal Rescue event 1.0)
-	//enums.ChaoIDStrJewelChao:            3.0, // Event (Animal Rescue event 1.0)
-	enums.ChaoIDStrNormalChao:           3.0, // Event (Animal Rescue event 1.0)
-	enums.ChaoIDStrOmochao:              3.0, // Event (Animal Rescue event 1.0)
+	enums.ChaoIDStrDarkChao:             3.7, // Event (Animal Rescue event 1.0)
+	enums.ChaoIDStrJewelChao:            3.7, // Event (Animal Rescue event 1.0)
+	//enums.ChaoIDStrNormalChao:           3.0, // Event (Animal Rescue event 1.0)
+	//enums.ChaoIDStrOmochao:              3.0, // Event (Animal Rescue event 1.0)
 	//enums.ChaoIDStrRCMonkey:             1.0, // Event (Animal Rescue event 1.0)
-	enums.ChaoIDStrRCSpring:             3.0,
-	enums.ChaoIDStrRCElectromagnet:      3.0,
-	enums.ChaoIDStrBabyCyanWisp:         3.0,
-	enums.ChaoIDStrBabyIndigoWisp:       3.0,
-	enums.ChaoIDStrBabyYellowWisp:       3.0,
-	//enums.ChaoIDStrRCPinwheel:           3.0,
-	enums.ChaoIDStrRCPiggyBank:          3.0,
-	enums.ChaoIDStrRCBalloon:            3.0,
-	//enums.ChaoIDStrEasterChao:           3.5, // Event (Easter; Increase Odds During Event)
+	enums.ChaoIDStrRCSpring:             3.7,
+	enums.ChaoIDStrRCElectromagnet:      3.7,
+	enums.ChaoIDStrBabyCyanWisp:         3.7,
+	enums.ChaoIDStrBabyIndigoWisp:       3.7,
+	enums.ChaoIDStrBabyYellowWisp:       3.7,
+	enums.ChaoIDStrRCPinwheel:           3.7,
+	//enums.ChaoIDStrRCPiggyBank:          3.0,
+	//enums.ChaoIDStrRCBalloon:            3.0,
+	enums.ChaoIDStrEasterChao:           3.7, // Event (Easter; Increase Odds During Event)
 	//enums.ChaoIDStrEasterBunny:          3.5, // Event (Easter; Increase Odds During Event)
 	//enums.ChaoIDStrMerlina:              1.5, // Event (Easter: Premium Roulette for Timed Mode Event Only; Obtainable through Rewards List Only for Story Event)
 	//enums.ChaoIDStrPurplePapurisu:       2.5, // Event (Puyo Puyo Quest)
 	//enums.ChaoIDStrSuketoudara:          2.5, // Event (Puyo Puyo Quest)
 	//enums.ChaoIDStrCarbuncle:            2.5, // Event (Puyo Puyo Quest: Premium Roulette for Timed Mode Event Only; Obtainable through Rewards List Only for Story Event)
-	enums.ChaoIDStrEggChao:           1.98,
-	enums.ChaoIDStrPumpkinChao:       1.98,
-	enums.ChaoIDStrSkullChao:         1.98,
-	enums.ChaoIDStrYacker:            1.98,
-	enums.ChaoIDStrRCGoldenPiggyBank: 1.98,
-	enums.ChaoIDStrWizardChao:        1.98,
-	//enums.ChaoIDStrRCTurtle:          1.98,
-	enums.ChaoIDStrRCUFO:             1.98,
+	enums.ChaoIDStrEggChao:           0.82,
+	enums.ChaoIDStrPumpkinChao:       0.82,
+	enums.ChaoIDStrSkullChao:         0.82,
+	enums.ChaoIDStrYacker:            0.82,
+	enums.ChaoIDStrRCGoldenPiggyBank: 0.82,
+	enums.ChaoIDStrWizardChao:        0.82,
+	enums.ChaoIDStrRCTurtle:          0.82,
+	//enums.ChaoIDStrRCUFO:             1.98,
 	//enums.ChaoIDStrRCBomber:          1.98,
-	//enums.ChaoIDStrStarShapedMissile:    1.98, // Event (Zazz Raid Boss; Increase Odds During Event)
-	enums.ChaoIDStrRCSatellite:          4.25, // Event (Zazz Raid Boss; Increase Odds During Event)
+	enums.ChaoIDStrStarShapedMissile:    0.82, // Event (Zazz Raid Boss; Increase Odds During Event)
+	//enums.ChaoIDStrRCSatellite:          1.98, // Event (Zazz Raid Boss; Increase Odds During Event)
 	//enums.ChaoIDStrRCMoonMech:           0.0, // Event (Zazz Raid Boss; Only Obtainable through the Raid Boss Roulette, which is currently unavailable)
 	//enums.ChaoIDStrRappy:                1.0, // Event (Phantasy Star Online 2)
 	//enums.ChaoIDStrKuna:                 1.0, // Event (Phantasy Star Online 2)
-	enums.ChaoIDStrMagLv1:               6.8, // Event (Phantasy Star Online 2)
+	//enums.ChaoIDStrMagLv1:               6.8, // Event (Phantasy Star Online 2)
 	//enums.ChaoIDStrBlowfishTransporter:  1.98, // Event (Tropical Coast; Increase Odds During Event)
 	//enums.ChaoIDStrMotherWisp:           1.2, // Event (Tropical Coast: Premium Roulette for Timed Mode Event Only; Obtainable through Rewards List Only for Story Event)
 	//enums.ChaoIDStrMarineChao:           1.98, // Event (Tropical Coast; Increase Odds During Event)
 	//enums.ChaoIDStrGenesis:              1.5, // Event (Birthday: Premium Roulette for Timed Mode Event Only; Obtainable through Rewards List Only for Story Event)
-	enums.ChaoIDStrCartridge:            1.98, // Event (Birthday; Increase Odds During Event)
+	enums.ChaoIDStrCartridge:            0.82, // Event (Birthday; Increase Odds During Event)
 	//enums.ChaoIDStrDeathEgg:             1.0, // Event (Birthday; Increase Odds During Event)
 	//enums.ChaoIDStrRCFighter:            1.98,
-	//enums.ChaoIDStrRCHovercraft:         1.98,
-	enums.ChaoIDStrRCHelicopter:         1.98,
+	enums.ChaoIDStrRCHovercraft:         0.82,
+	//enums.ChaoIDStrRCHelicopter:         1.98,
 	//enums.ChaoIDStrGreenCrystalMonsterS: 1.98,
-	//enums.ChaoIDStrGreenCrystalMonsterL: 1.98,
-	enums.ChaoIDStrRCAirship:            1.98,
+	enums.ChaoIDStrGreenCrystalMonsterL: 0.82,
+	//enums.ChaoIDStrRCAirship:            1.98,
 	//enums.ChaoIDStrMagicLamp:            2.0, // Event (Desert Ruins and Animal Rescue 2.0; Increase Odds During Event)
-	//enums.ChaoIDStrDesertChao:           3.0, // Event (Desert Ruins; Increase Odds During Event)
+	enums.ChaoIDStrDesertChao:           0.82, // Event (Desert Ruins; Increase Odds During Event)
 	//enums.ChaoIDStrErazorDjinn:          2.5, // Event (Desert Ruins: Premium Roulette for Timed Mode Event Only; Obtainable through Rewards List Only for Story Event)
 	//enums.ChaoIDStrNightopian:           2.0, // Event (NiGHTS)
 	//enums.ChaoIDStrNiGHTS:               2.0, // Event (NiGHTS)
 	//enums.ChaoIDStrReala:                2.0, // Event (NiGHTS)
 	//enums.ChaoIDStrSonicOmochao:         1.98, // Event (Team Sonic Omochao)
 	//enums.ChaoIDStrTailsOmochao:         1.98, // Event (Team Sonic Omochao)
-	//enums.ChaoIDStrKnucklesOmochao:      1.98, // Event (Team Sonic Omochao)
+	enums.ChaoIDStrKnucklesOmochao:      0.82, // Event (Team Sonic Omochao)
 	//enums.ChaoIDStrKingBoomBoo:          1.5, // Event (Halloween: Premium Roulette for Timed Mode Event Only; Obtainable through Rewards List Only for Story Event)
-	enums.ChaoIDStrBoo:                  1.98, // Event (Halloween; Increase Odds During Event)
+	//enums.ChaoIDStrBoo:                  1.98, // Event (Halloween; Increase Odds During Event)
 	//enums.ChaoIDStrHalloweenChao:        1.98, // Event (Halloween; Increase Odds During Event)
 	//enums.ChaoIDStrHeavyBomb:            1.2, // Event (Fantasy Zone)
 	//enums.ChaoIDStrOPapa:                1.5, // Event (Fantasy Zone)
-	//enums.ChaoIDStrOpaOpa:               1.5, // Event (Fantasy Zone)
-	//enums.ChaoIDStrBlockBomb:  1.98,
-	enums.ChaoIDStrHunkofMeat: 1.98,
+	enums.ChaoIDStrOpaOpa:               1.81, // Event (Fantasy Zone)
+	enums.ChaoIDStrBlockBomb:  0.82,
+	//enums.ChaoIDStrHunkofMeat: 1.98,
 	// enums.ChaoIDStrYeti:                 1.5, // Event (Christmas)
 	// enums.ChaoIDStrSnowChao:             2.0, // Event (Christmas)
 	// enums.ChaoIDStrChristmasYeti:        1.5, // Event (Christmas)
@@ -126,34 +126,34 @@ var RandomChaoWheelChaoPrizes = map[string]float64{
 	// enums.ChaoIDStrIdeya:                1.5, // Event (Christmas NiGHTS)
 	// enums.ChaoIDStrChristmasNightopian:  1.5, // Event (Christmas NiGHTS)
 	//enums.ChaoIDStrOrbot:      1.98,
-	//enums.ChaoIDStrCubot:      1.98,
-	enums.ChaoIDStrLightChaos: 1.8,
-	enums.ChaoIDStrHeroChaos:  1.8,
-	enums.ChaoIDStrDarkChaos:  1.8,
-	enums.ChaoIDStrChip:       1.8,
-	enums.ChaoIDStrShahra:               4.0, // Runners' League Story Mode
-	enums.ChaoIDStrCaliburn:         1.8,
-	enums.ChaoIDStrKingArthursGhost: 1.8,
+	enums.ChaoIDStrCubot:      0.82,
+	enums.ChaoIDStrLightChaos: 1.55,
+	enums.ChaoIDStrHeroChaos:  1.55,
+	enums.ChaoIDStrDarkChaos:  1.55,
+	enums.ChaoIDStrChip:       1.55,
+	//enums.ChaoIDStrShahra:               4.0, // Runners' League Story Mode
+	enums.ChaoIDStrCaliburn:         1.55,
+	enums.ChaoIDStrKingArthursGhost: 1.55,
 	//enums.ChaoIDStrRCTornado:        1.8,
-	//enums.ChaoIDStrRCBattleCruiser:  1/8,
-	enums.ChaoIDStrRedCrystalMonsterS: 1.8,
+	enums.ChaoIDStrRCBattleCruiser:  1.55,
+	//enums.ChaoIDStrRedCrystalMonsterS: 1.8,
 	//enums.ChaoIDStrRedCrystalMonsterL: 1.8,
-	//enums.ChaoIDStrGoldenGoose:        1.8,
+	enums.ChaoIDStrGoldenGoose:        1.55,
 	//enums.ChaoIDStrRCPirateSpaceship: 1.8,
-	enums.ChaoIDStrGoldenAngel:       1.8,
-	//enums.ChaoIDStrRCTornado2:           1.8, // Event (Sonic Adventure; Increase Odds During Event)
+	//enums.ChaoIDStrGoldenAngel:       1.8,
+	enums.ChaoIDStrRCTornado2:           1.55, // Event (Sonic Adventure; Increase Odds During Event)
 	//enums.ChaoIDStrChaos:                1.8, // Event (Sonic Adventure; Increase Odds During Event)
-	enums.ChaoIDStrOrca:                 1.98, // Event (Sonic Adventure; Increase Odds During Event)
+	//enums.ChaoIDStrOrca:                 1.98, // Event (Sonic Adventure; Increase Odds During Event)
 	//enums.ChaoIDStrChaoWalker:           0.0, // Daily Battle
-	//enums.ChaoIDStrDarkQueen:            0.0, // Runners' League Timed Mode
+	enums.ChaoIDStrDarkQueen:            1.81, // Runners' League Timed Mode
 	//enums.ChaoIDStrRCBlockFace: 1.8,
 	//enums.ChaoIDStrDFekt:                0.0, // Revival Event (assets TBD)
-	enums.ChaoIDStrDarkChaoWalker:       1.8, // Daily Battle?
-	//enums.ChaoIDStrPrideChaoL:           2.2, // Revival Event (Pride Month Celebration)
-	//enums.ChaoIDStrPrideChaoG:           2.2, // Revival Event (Pride Month Celebration)
-	//enums.ChaoIDStrPrideChaoB:           2.2, // Revival Event (Pride Month Celebration)
-	//enums.ChaoIDStrPrideChaoT:           2.2, // Revival Event (Pride Month Celebration)
-	//enums.ChaoIDStrPrideChaoP:           2.2, // Revival Event (Pride Month Celebration)
-	//enums.ChaoIDStrPrideChaoA:           2.2, // Revival Event (Pride Month Celebration)
-	//enums.ChaoIDStrPrideChaoNB:          2.2, // Revival Event (Pride Month Celebration)
+	//enums.ChaoIDStrDarkChaoWalker:       1.8, // Daily Battle?
+	enums.ChaoIDStrPrideChaoL:           3.09, // Revival Event (Pride Month Celebration)
+	enums.ChaoIDStrPrideChaoG:           3.09, // Revival Event (Pride Month Celebration)
+	enums.ChaoIDStrPrideChaoB:           3.09, // Revival Event (Pride Month Celebration)
+	enums.ChaoIDStrPrideChaoT:           3.09, // Revival Event (Pride Month Celebration)
+	enums.ChaoIDStrPrideChaoP:           3.09, // Revival Event (Pride Month Celebration)
+	enums.ChaoIDStrPrideChaoA:           3.09, // Revival Event (Pride Month Celebration)
+	enums.ChaoIDStrPrideChaoNB:          3.09, // Revival Event (Pride Month Celebration)
 }

--- a/consts/randomChaoItemList.go
+++ b/consts/randomChaoItemList.go
@@ -67,7 +67,7 @@ var RandomChaoWheelChaoPrizes = map[string]float64{
 	enums.ChaoIDStrBabyIndigoWisp:       3.7,
 	enums.ChaoIDStrBabyYellowWisp:       3.7,
 	enums.ChaoIDStrRCPinwheel:           3.7,
-	//enums.ChaoIDStrRCPiggyBank:          3.0,
+	enums.ChaoIDStrRCPiggyBank:          3.7,
 	//enums.ChaoIDStrRCBalloon:            3.0,
 	enums.ChaoIDStrEasterChao:           3.7, // Event (Easter; Increase Odds During Event)
 	//enums.ChaoIDStrEasterBunny:          3.5, // Event (Easter; Increase Odds During Event)

--- a/consts/randomChaoItemList.go
+++ b/consts/randomChaoItemList.go
@@ -92,7 +92,7 @@ var RandomChaoWheelChaoPrizes = map[string]float64{
 	//enums.ChaoIDStrMagLv1:               6.8, // Event (Phantasy Star Online 2)
 	//enums.ChaoIDStrBlowfishTransporter:  1.98, // Event (Tropical Coast; Increase Odds During Event)
 	//enums.ChaoIDStrMotherWisp:           1.2, // Event (Tropical Coast: Premium Roulette for Timed Mode Event Only; Obtainable through Rewards List Only for Story Event)
-	//enums.ChaoIDStrMarineChao:           1.98, // Event (Tropical Coast; Increase Odds During Event)
+	enums.ChaoIDStrMarineChao:           0.82, // Event (Tropical Coast; Increase Odds During Event)
 	//enums.ChaoIDStrGenesis:              1.5, // Event (Birthday: Premium Roulette for Timed Mode Event Only; Obtainable through Rewards List Only for Story Event)
 	enums.ChaoIDStrCartridge:            0.82, // Event (Birthday; Increase Odds During Event)
 	//enums.ChaoIDStrDeathEgg:             1.0, // Event (Birthday; Increase Odds During Event)

--- a/consts/randomChaoItemList.go
+++ b/consts/randomChaoItemList.go
@@ -95,7 +95,7 @@ var RandomChaoWheelChaoPrizes = map[string]float64{
 	enums.ChaoIDStrMarineChao:           0.82, // Event (Tropical Coast; Increase Odds During Event)
 	//enums.ChaoIDStrGenesis:              1.5, // Event (Birthday: Premium Roulette for Timed Mode Event Only; Obtainable through Rewards List Only for Story Event)
 	enums.ChaoIDStrCartridge:            0.82, // Event (Birthday; Increase Odds During Event)
-	//enums.ChaoIDStrDeathEgg:             1.0, // Event (Birthday; Increase Odds During Event)
+	enums.ChaoIDStrDeathEgg:             1.47, // Event (Birthday; Increase Odds During Event)
 	//enums.ChaoIDStrRCFighter:            1.98,
 	enums.ChaoIDStrRCHovercraft:         0.82,
 	//enums.ChaoIDStrRCHelicopter:         1.98,
@@ -132,16 +132,16 @@ var RandomChaoWheelChaoPrizes = map[string]float64{
 	enums.ChaoIDStrDarkChaos:  1.55,
 	enums.ChaoIDStrChip:       1.55,
 	//enums.ChaoIDStrShahra:               4.0, // Runners' League Story Mode
-	enums.ChaoIDStrCaliburn:         1.55,
-	enums.ChaoIDStrKingArthursGhost: 1.55,
+	enums.ChaoIDStrCaliburn:         1.47,
+	enums.ChaoIDStrKingArthursGhost: 1.47,
 	//enums.ChaoIDStrRCTornado:        1.8,
-	enums.ChaoIDStrRCBattleCruiser:  1.55,
+	enums.ChaoIDStrRCBattleCruiser:  1.47,
 	//enums.ChaoIDStrRedCrystalMonsterS: 1.8,
 	//enums.ChaoIDStrRedCrystalMonsterL: 1.8,
-	enums.ChaoIDStrGoldenGoose:        1.55,
+	enums.ChaoIDStrGoldenGoose:        1.47,
 	//enums.ChaoIDStrRCPirateSpaceship: 1.8,
 	//enums.ChaoIDStrGoldenAngel:       1.8,
-	enums.ChaoIDStrRCTornado2:           1.55, // Event (Sonic Adventure; Increase Odds During Event)
+	enums.ChaoIDStrRCTornado2:           1.47, // Event (Sonic Adventure; Increase Odds During Event)
 	//enums.ChaoIDStrChaos:                1.8, // Event (Sonic Adventure; Increase Odds During Event)
 	//enums.ChaoIDStrOrca:                 1.98, // Event (Sonic Adventure; Increase Odds During Event)
 	//enums.ChaoIDStrChaoWalker:           0.0, // Daily Battle

--- a/consts/randomChaoItemList.go
+++ b/consts/randomChaoItemList.go
@@ -62,7 +62,7 @@ var RandomChaoWheelChaoPrizes = map[string]float64{
 	enums.ChaoIDStrOmochao:              3.0, // Event (Animal Rescue event 1.0)
 	//enums.ChaoIDStrRCMonkey:             1.0, // Event (Animal Rescue event 1.0)
 	enums.ChaoIDStrRCSpring:             3.0,
-	enums.ChaoIDStrRCElectromagnet:      2.0,
+	enums.ChaoIDStrRCElectromagnet:      3.0,
 	enums.ChaoIDStrBabyCyanWisp:         3.0,
 	enums.ChaoIDStrBabyIndigoWisp:       3.0,
 	enums.ChaoIDStrBabyYellowWisp:       3.0,
@@ -94,7 +94,7 @@ var RandomChaoWheelChaoPrizes = map[string]float64{
 	//enums.ChaoIDStrMotherWisp:           1.2, // Event (Tropical Coast: Premium Roulette for Timed Mode Event Only; Obtainable through Rewards List Only for Story Event)
 	//enums.ChaoIDStrMarineChao:           1.98, // Event (Tropical Coast; Increase Odds During Event)
 	//enums.ChaoIDStrGenesis:              1.5, // Event (Birthday: Premium Roulette for Timed Mode Event Only; Obtainable through Rewards List Only for Story Event)
-	//enums.ChaoIDStrCartridge:            1.5, // Event (Birthday; Increase Odds During Event)
+	enums.ChaoIDStrCartridge:            1.98, // Event (Birthday; Increase Odds During Event)
 	//enums.ChaoIDStrDeathEgg:             1.0, // Event (Birthday; Increase Odds During Event)
 	//enums.ChaoIDStrRCFighter:            1.98,
 	//enums.ChaoIDStrRCHovercraft:         1.98,


### PR DESCRIPTION
Please pull the change authored on 8 June 2025 for the June Roulette Remix odds next Thursday 12 June.